### PR TITLE
Add website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Maintainer: Bo-Shiang Ke <naivete0907@gmail.com>
 Description: Ke, B. S., Chiang, A. J., & Chang, Y. C. I. (2018) <doi:10.1080/10543406.2017.1377728> provide two theoretical methods (influence function and local influence) based on the area under the receiver operating characteristic curve (AUC) to quantify the numerical impact of each observation to the overall AUC. Alternative graphical tools, cumulative lift charts, are proposed to reveal the existences and approximate locations of those influential observations through data visualization.
 License: GPL-3
 BugReports: https://github.com/BoShiangKe/InfluenceAUC/issues
+URL: https://boshiangke.github.io/InfluenceAUC/
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.0


### PR DESCRIPTION
Also consider adding it in the About section in the gh repo About section on the homepage. (top right)

Also, possibly update the gh actions as they seem outdated. `usethis::use_github_action("check-standard")` and `usethis::use_github_action("pr-commands")`.

## Objective
Make it discoverable



